### PR TITLE
chore: update add issues to project action

### DIFF
--- a/.github/workflows/add_issue_new_projects.yml
+++ b/.github/workflows/add_issue_new_projects.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   add_issue_frontend:
+    # yamllint disable rule:line-length
     runs-on: ubuntu-latest
     steps:
       - name: "Add to front end project board"
@@ -26,14 +27,13 @@ jobs:
                 }
               }
             }' -f project=$PROJECT_ID -f issue=$ISSUE_ID -f user=$USER
+
       - name: "Add repo identifier label"
         run: |
           gh api graphql -f query='
-            mutation($user:String!, $issue:ID!, $labels:[ID!]!) {
-              addLabelsToLabelable(input: {clientMutationId: $user, labelableId: $issue, labelIds: $labels}) {
+            mutation($user:String!, $issue:ID!) {
+              addLabelsToLabelable(input: {clientMutationId: $user, labelableId: $issue, labelIds: ["LA_kwDOGb2K7s8AAAABDzKRyA", "LA_kwDOGb2K7s8AAAABDzKPFQ"]}) {
                 clientMutationId
               }
-            }
-            variables {
-              labels: ["LA_kwDOGb2K7s8AAAABDzKRyA", "LA_kwDOGb2K7s8AAAABDzKPFQ"]
-              }' -f issue=$ISSUE_ID -f user=$USER
+            }' -f issue=$ISSUE_ID -f user=$USER
+      # yamllint enable rule:line-length

--- a/.github/workflows/add_issue_new_projects.yml
+++ b/.github/workflows/add_issue_new_projects.yml
@@ -1,37 +1,39 @@
 ---
 
-name: Add Issues To Project Board
+name: "Add Issues To Project Board"
 
 "on":
   issues:
-    types: [opened]
+    types:
+      - opened
+env:
+  GH_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+  PROJECT_ID: ${{ secrets.FRONT_END_PROJECT_ID }}
+  ISSUE_ID: ${{ github.event.issue.node_id }}
+  USER: ${{ github.actor }}
 
 jobs:
-  add_issue:
+  add_issue_frontend:
     runs-on: ubuntu-latest
     steps:
-      - name: Add issue project board
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
-          PROJECT_ID: ${{ secrets.FRONT_END_PROJECT_ID }}
-          ISSUE_ID: ${{ github.event.issue.node_id }}
+      - name: "Add to front end project board"
         run: |
           gh api graphql -f query='
-            mutation($project:ID!, $issue:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
-                projectNextItem {
+            mutation($user:String!, $project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+                item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id'
-
-  label_issues:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Add "website testing" label
-        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
-        with:
-          add-labels: "website, testing"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID -f user=$USER
+      - name: "Add repo identifier label"
+        run: |
+          gh api graphql -f query='
+            mutation($user:String!, $issue:ID!, $labels:[ID!]!) {
+              addLabelsToLabelable(input: {clientMutationId: $user, labelableId: $issue, labelIds: $labels}) {
+                clientMutationId
+              }
+            }
+            variables {
+              labels: ["LA_kwDOGb2K7s8AAAABDzKRyA", "LA_kwDOGb2K7s8AAAABDzKPFQ"]
+              }' -f issue=$ISSUE_ID -f user=$USER


### PR DESCRIPTION
The GitHub projects API has been replaced with ProjectsV2. This PR corrects the add issues to project action.

Also removes the external GH action and replaces with a simple GQL mutation for labelling