### PR TITLE
Revert Lighthouse logging

### DIFF
--- a/cypress/e2e/lighthouse.spec.js
+++ b/cypress/e2e/lighthouse.spec.js
@@ -9,10 +9,6 @@ pages.forEach((page) => {
   
       it(`The page meets lighthouse baseline`, () => {
         cy.lighthouse(page.lighthouse)
-        .then((report) => {
-          const { errors, results, txt } = report
-          cy.log(report.txt)
-        });
       });
     });
   });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -5,32 +5,7 @@ module.exports = (on, config) => {
     prepareAudit(launchOptions)
   })
 
-  on('task', {
-    async lighthouse(allOptions) {
-      let txt
-      const lighthouseTask = lighthouse((lighthouseReport) => {
-        let lighthouseScoreText = ''
-        let lighthouseResult = lighthouseReport?.lhr?.categories
-        let lighthousePerformance =
-          'Performance: ' + lighthouseResult?.performance?.score + '\n'
-        let lighthouseAccessibility =
-          'Accessibility: ' + lighthouseResult?.accessibility?.score + '\n'
-        let lighthouseBestPractices =
-          'Best Practices: ' + lighthouseResult?.['best-practices']?.score + '\n'
-        let lighthouseSEO = 'SEO: ' + lighthouseResult?.seo?.score + '\n'
-        lighthouseScoreText =
-          lighthousePerformance +
-          lighthouseAccessibility +
-          lighthouseBestPractices +
-          lighthouseSEO
-
-        console.log(lighthouseScoreText)
-        txt = lighthouseScoreText
-      })
-
-      const report = await lighthouseTask(allOptions)
-      report.txt = txt
-      return report
-    },
-  })
+  on("task", {
+    lighthouse: lighthouse(), // calling the function is important
+  });
 }


### PR DESCRIPTION
Reverting the Lighthouse logging change I made previously.

It was causing the lighthouse tests to fail, (they were passing locally)

I have access to the cypress dashboard now so I can run the tests there prior to future changes.